### PR TITLE
fix-bugs-about-multi-sheet-for-classes

### DIFF
--- a/gpa/calculator/writer.py
+++ b/gpa/calculator/writer.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import os
-
+import openpyxl
 
 class Writer:
     def __init__(self, data_group, total=None):
@@ -8,12 +8,19 @@ class Writer:
         self.total = total
 
     def write_to_excel(self, name, total_name="全部"):
+        
+        i = 0
+        # None == ALL
         if self.total is not None:
             if not os.path.isfile(name):
+                print("save in all")
                 self.total.reset_index(drop=True).to_excel(name, sheet_name=total_name)
-        for df in self.data_group:
-            if not os.path.isfile(name):
-                df[1].reset_index(drop=True).to_excel(name, sheet_name=df[0])
-                continue
-            with pd.ExcelWriter(name, engine='openpyxl', mode='a') as writer:
-                df[1].reset_index(drop=True).to_excel(writer, sheet_name=df[0])
+        else:
+            print("save by class")
+            if not os.path.isfile(name):  
+                workbook = openpyxl.Workbook()
+                workbook.save(name)   
+            # excel exists 
+            with pd.ExcelWriter(name, engine='openpyxl', mode='a') as writer:      
+                for df in self.data_group:
+                    df[1].reset_index(drop=True).to_excel(writer, sheet_name=df[0])


### PR DESCRIPTION
原代码在统计多个班级时，保存新班级会覆盖之前的sheet，导致只能保留最后一个班级的sheet。这是由于for循环中反复使用ExcelWriter导致的。修改逻辑后可以正常保存多个班级sheet。